### PR TITLE
Thumbnail cut in full screen fix.

### DIFF
--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -370,6 +370,8 @@ $ig-transparent: rgba(0, 0, 0, 0) !default;
     vertical-align: middle;
     width: 100%;
     line-height: 0;
+    max-height: 61px;  //92 * 9 / 16 (image width * aspect ratio)
+    object-fit: cover; //covers the area without stretching image
   }
 
   &.active,

--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -160,7 +160,7 @@ $ig-transparent: rgba(0, 0, 0, 0) !default;
   }
 
   .image-gallery-slide .image-gallery-image {
-    max-height: calc(100vh - 80px); // 80 px for the thumbnail space
+    max-height: calc(100vh - 110px); // 110 px for the thumbnail space
   }
 
   &.left,

--- a/styles/scss/image-gallery.scss
+++ b/styles/scss/image-gallery.scss
@@ -160,7 +160,7 @@ $ig-transparent: rgba(0, 0, 0, 0) !default;
   }
 
   .image-gallery-slide .image-gallery-image {
-    max-height: calc(100vh - 110px); // 110 px for the thumbnail space
+    max-height: calc(100vh - 80px); // 80 px for the thumbnail space.
   }
 
   &.left,


### PR DESCRIPTION
If the thumbnails have an aspect ratio taller than 16:9 the thumbnail gets cut. This will fix it.